### PR TITLE
fix: prefer `globalThis` over `window` in Node 19

### DIFF
--- a/src/crypto.ts
+++ b/src/crypto.ts
@@ -10,7 +10,7 @@ async function loadCrypto(): Promise<Crypto> {
     ) {
         // Running in browsers released after 2017, and other
         // runtimes with `globalThis` like Deno or CloudFlare Workers
-        const crypto = window.crypto || globalThis.crypto
+        const crypto = globalThis.crypto || window.crypto
 
         return new Promise((resolve) => resolve(crypto))
     } else {


### PR DESCRIPTION
Fixes #34

This is a hotfix that allows `pagecrypt` usage with Node 19.

For some reason, the [window/globalThis check](https://github.com/Greenheart/pagecrypt/blob/c1590740f228f25c5a56be1d7754943da7ebf236/src/crypto.ts#L7-L10) is evaluated differently in Node 19.

Setting `globalThis` before `window` avoids the reference error thrown by Node when the branch is evaluated.

I've tested this in Node 19 and Node 16.